### PR TITLE
Wiki collaborators

### DIFF
--- a/app/assets/javascripts/collaborations.coffee
+++ b/app/assets/javascripts/collaborations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/collaborations.scss
+++ b/app/assets/stylesheets/collaborations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Collaborations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,12 @@ class ApplicationController < ActionController::Base
   include Pundit
   protect_from_forgery with: :exception
 
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  private
+
+  def user_not_authorized
+    flash[:alert] = "You are not authorized to perform this action."
+    redirect_to(request.referrer || root_path)
+  end
 end

--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -1,0 +1,2 @@
+class CollaborationsController < ApplicationController
+end

--- a/app/controllers/collaborations_controller.rb
+++ b/app/controllers/collaborations_controller.rb
@@ -1,2 +1,31 @@
 class CollaborationsController < ApplicationController
+  before_action :find_wiki
+
+  def create
+    @collaboration = Collaboration.new(wiki_id: @wiki.id, user_id: params[:user_id])
+    if @collaboration.save
+      flash[:notice] = "Your wiki was updated with a new collaborator."
+      redirect_to edit_wiki_path(@wiki)
+    else
+      flash[:error] = "There was an error updating your wiki. Please try again."
+      render :show
+    end
+  end
+
+  def destroy
+    @collaboration = Collaboration.find(params[:id])
+    if @collaboration.destroy
+      flash[:notice] = "Collaborator was removed and wiki was successfully updated."
+      redirect_to edit_wiki_path(@wiki)
+    else
+      flash[:error] = "There was an error updating your wiki. Please try again."
+      render :show
+    end
+  end
+
+  private
+
+  def find_wiki
+    @wiki = Wiki.find(params[:wiki_id])
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,8 @@
 class UsersController < ApplicationController
+  def index
+    @users = User.all
+  end
+
   def new
     @user = User.new
   end

--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -8,10 +8,12 @@ class WikisController < ApplicationController
 
   def show
     @wiki = Wiki.find(params[:id])
+    authorize @wiki
   end
 
   def new
     @wiki = Wiki.new
+    authorize @wiki
   end
 
   def create
@@ -20,6 +22,7 @@ class WikisController < ApplicationController
     @wiki.body = params[:wiki][:body]
     @wiki.private = params[:wiki][:private]
     @wiki.user = current_user
+    authorize @wiki
 
     if @wiki.save
       flash[:notice] = "Wiki was saved."
@@ -33,6 +36,7 @@ class WikisController < ApplicationController
   def edit
     @wiki = Wiki.find(params[:id])
     @users = User.all
+    authorize @wiki
   end
 
   def update
@@ -40,7 +44,8 @@ class WikisController < ApplicationController
     @wiki.title = params[:wiki][:title]
     @wiki.body = params[:wiki][:body]
     @wiki.private = params[:wiki][:private]
-
+    authorize @wiki
+    
     if @wiki.save
       flash[:notice] = "Wiki was updated."
       redirect_to @wiki

--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -32,6 +32,7 @@ class WikisController < ApplicationController
 
   def edit
     @wiki = Wiki.find(params[:id])
+    @users = User.all
   end
 
   def update

--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -3,7 +3,7 @@ class WikisController < ApplicationController
   before_filter :authenticate_user!, except: [:index]
 
   def index
-    @wiki = Wiki.visible_to(current_user)
+    @wiki = policy_scope(Wiki)
   end
 
   def show

--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -7,7 +7,7 @@ class WikisController < ApplicationController
   end
 
   def show
-    @wiki = Wiki.visible_to(current_user).find(params[:id])
+    @wiki = Wiki.find(params[:id])
   end
 
   def new

--- a/app/helpers/collaborations_helper.rb
+++ b/app/helpers/collaborations_helper.rb
@@ -1,0 +1,2 @@
+module CollaborationsHelper
+end

--- a/app/models/collaboration.rb
+++ b/app/models/collaboration.rb
@@ -1,0 +1,4 @@
+class Collaboration < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :wiki
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable
 
   has_many :wikis
-  has_many :collaborations
+  has_many :collaborations, through: :wikis
 
   before_save { self.role ||= :standard}
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable
 
   has_many :wikis
+  has_many :collaborations
 
   before_save { self.role ||= :standard}
 

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -3,5 +3,9 @@ class Wiki < ActiveRecord::Base
   has_many :collaborations
   has_many :users, through: :collaborations
 
-  scope :visible_to, -> (user) { user && ((user.role == 'premium') || (user.role == 'admin')) ? all : where(private: false)  }
+  scope :visible_to, -> (user) { user && ((user.role == 'premium') || (user.role == 'admin')) ? all : where(private: false) }
+
+  def collaboration_for(user)
+    collaborations.where(user: user).first
+  end
 end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -1,5 +1,6 @@
 class Wiki < ActiveRecord::Base
   belongs_to :user
+  has_many :collaborations
 
   scope :visible_to, -> (user) { user && ((user.role == 'premium') || (user.role == 'admin')) ? all : where(private: false)  }
 end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -3,8 +3,6 @@ class Wiki < ActiveRecord::Base
   has_many :collaborations
   has_many :users, through: :collaborations
 
-  scope :visible_to, -> (user) { user && ((user.role == 'premium') || (user.role == 'admin')) ? all : where(private: false) }
-
   def collaboration_for(user)
     collaborations.where(user: user).first
   end

--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -1,6 +1,7 @@
 class Wiki < ActiveRecord::Base
   belongs_to :user
   has_many :collaborations
+  has_many :users, through: :collaborations
 
   scope :visible_to, -> (user) { user && ((user.role == 'premium') || (user.role == 'admin')) ? all : where(private: false)  }
 end

--- a/app/policies/wiki_policy.rb
+++ b/app/policies/wiki_policy.rb
@@ -30,7 +30,7 @@ class WikiPolicy < ApplicationPolicy
       elsif user.present? && user.role == 'premium'
         all_wikis = scope.all
         all_wikis.each do |wiki|
-          if wiki.private != true || wiki.user == user || wiki.users.include?(user)
+          if !wiki.private? || wiki.user == user || wiki.users.include?(user)
             wikis << wiki
           end
         end

--- a/app/policies/wiki_policy.rb
+++ b/app/policies/wiki_policy.rb
@@ -1,4 +1,19 @@
 class WikiPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    record.private != true || (user.present? && ((user.role == 'admin') || record.user == user || record.users.include?(user)))
+  end
+
+  def update?
+    show?
+  end
+
+  def edit?
+    show?
+  end
 
   class Scope
     attr_reader :user, :scope
@@ -10,22 +25,20 @@ class WikiPolicy < ApplicationPolicy
 
     def resolve
       wikis = []
-      if !user
-        wikis = scope.where(private: false)
-      elsif user.role == 'admin'
+      if user.present? && user.role == 'admin'
         wikis = scope.all
-      elsif user.role == 'premium'
+      elsif user.present? && user.role == 'premium'
         all_wikis = scope.all
         all_wikis.each do |wiki|
-          if !(wiki.private?) || wiki.user == user || wiki.collaborations.include?(user)
+          if wiki.private != true || wiki.user == user || wiki.users.include?(user)
             wikis << wiki
           end
         end
       else
         all_wikis = scope.all
-        wikis = []
+        wikis =[]
         all_wikis.each do |wiki|
-          if !(wiki.private?) || wiki.collaborations.include?(user)
+          if wiki.private != true || wiki.users.include?(user)
             wikis << wiki
           end
         end

--- a/app/policies/wiki_policy.rb
+++ b/app/policies/wiki_policy.rb
@@ -1,0 +1,36 @@
+class WikiPolicy < ApplicationPolicy
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      wikis = []
+      if !user
+        wikis = scope.where(private: false)
+      elsif user.role == 'admin'
+        wikis = scope.all
+      elsif user.role == 'premium'
+        all_wikis = scope.all
+        all_wikis.each do |wiki|
+          if !(wiki.private?) || wiki.user == user || wiki.collaborations.include?(user)
+            wikis << wiki
+          end
+        end
+      else
+        all_wikis = scope.all
+        wikis = []
+        all_wikis.each do |wiki|
+          if !(wiki.private?) || wiki.collaborations.include?(user)
+            wikis << wiki
+          end
+        end
+      end
+      wikis
+    end
+  end
+end

--- a/app/views/wikis/edit.html.erb
+++ b/app/views/wikis/edit.html.erb
@@ -1,32 +1,20 @@
 <h1>Edit Wiki</h1>
+  <%= render "wikis/form" %>
 
-<div class="row">
-  <div class="col-md-4">
-
-  </div>
-  <div class="col-md-8">
-    <%= form_for @wiki do |f| %>
-      <div class="form-group">
-        <%= f.label :title %>
-        <%= f.text_field :title, class: 'form-control', placeholder: "Enter wiki title" %>
-      </div>
-      <div class="form-group">
-        <%= f.label :body %>
-        <%= f.text_area :body, rows: 8, class: 'form-control', placeholder: "Enter wiki body" %>
-      </div>
-      <% if current_user.admin? || current_user.premium? %>
-        <div class="col-md-8">
-          <div class="form-group">
-            <%= f.label :private, class: 'checkbox' do %>
-              <%= f.check_box :private %> Private
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-      <div class="form-group">
-        <%= f.submit "Save", class: 'btn btn-success' %>
-      </div>
+<% if current_user.premium? || current_user.admin? %>
+  <h3>Manage Collaborators</h3>
+    <table class= 'table'>
+      <% @users.each do |user| %>
+      <tr>
+        <td><%= user.name %></td>
+        <td>
+          <% if @wiki.users.include? user %>
+            <%= link_to "Remove Collaborator", wiki_collaborations_path(@wiki, @wiki.collaboration_for(user)), method: :delete, class: 'btn btn-danger' %>
+          <% else %>
+            <%= link_to "Add Collaborator", wiki_collaborations_path(@wiki, user_id: user.id), method: :post, class: 'btn btn-success' %>
+          <% end %>
+        </td>
+      </tr>
     <% end %>
-
-  </div>
-</div>
+  </table>
+<% end %>

--- a/app/views/wikis/edit.html.erb
+++ b/app/views/wikis/edit.html.erb
@@ -9,7 +9,7 @@
         <td><%= user.name %></td>
         <td>
           <% if @wiki.users.include? user %>
-            <%= link_to "Remove Collaborator", wiki_collaborations_path(@wiki, @wiki.collaboration_for(user)), method: :delete, class: 'btn btn-danger' %>
+            <%= link_to "Remove Collaborator", wiki_collaboration_path(@wiki, @wiki.collaboration_for(user)), method: :delete, class: 'btn btn-danger' %>
           <% else %>
             <%= link_to "Add Collaborator", wiki_collaborations_path(@wiki, user_id: user.id), method: :post, class: 'btn btn-success' %>
           <% end %>

--- a/app/views/wikis/index.html.erb
+++ b/app/views/wikis/index.html.erb
@@ -11,6 +11,7 @@
     <div class="media-body">
       <h4 class="media-heading">
         <%= link_to wiki.title, wiki %>
+        <% if wiki.private %> <button type="button" class="btn btn-xs btn-warning">Private</button> <% end %>
       </h4>
     </div>
   </div>

--- a/app/views/wikis/new.html.erb
+++ b/app/views/wikis/new.html.erb
@@ -1,11 +1,2 @@
 <h1>New Wiki</h1>
-
- <div class="row">
-   <div class="col-md-4">
-   </div>
-   <div class="col-md-8">
-
-     <%= render "wikis/form" %>
-
-   </div>
- </div>
+  <%= render "wikis/form" %>

--- a/app/views/wikis/show.html.erb
+++ b/app/views/wikis/show.html.erb
@@ -1,5 +1,4 @@
-<h1><%= markdown (@wiki.title) %></h1>
-
+<p><h1><%= markdown (@wiki.title) %></h1>
 <div class="row">
   <div class="col-md-8">
     <p><%= markdown(@wiki.body) %></p>
@@ -13,5 +12,7 @@
     <%= link_to "Delete Wiki", @wiki, method: :delete, class: 'btn btn-danger', data: {confirm: 'Are you sure you want to delete this wiki?'} %>
 <% end %>
   <p><small>Post created <%= time_ago_in_words(@wiki.created_at)%> ago.</small></p>
+
+  <% if @wiki.private %> <button type="button" class="btn btn-xs btn-warning">Private</button> <% end %>
   </div>
 </div>

--- a/app/views/wikis/show.html.erb
+++ b/app/views/wikis/show.html.erb
@@ -1,4 +1,4 @@
-<h1><%= @wiki.title %></h1>
+<h1><%= markdown (@wiki.title) %></h1>
 
 <div class="row">
   <div class="col-md-8">
@@ -12,5 +12,6 @@
 <% if user_is_authorized_to_delete_wiki? %>
     <%= link_to "Delete Wiki", @wiki, method: :delete, class: 'btn btn-danger', data: {confirm: 'Are you sure you want to delete this wiki?'} %>
 <% end %>
+  <p><small>Post created <%= time_ago_in_words(@wiki.created_at)%> ago.</small></p>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  resources :wikis
+  resources :wikis do
+    resources :collaborations, only: [:create, :destroy]
+  end
   resources :charges, only: [:new, :create]
 
   devise_for :users

--- a/db/migrate/20160325055522_create_collaborations.rb
+++ b/db/migrate/20160325055522_create_collaborations.rb
@@ -1,0 +1,11 @@
+class CreateCollaborations < ActiveRecord::Migration
+  def change
+    create_table :collaborations do |t|
+      t.integer :user_id
+      t.integer :wiki_id
+
+      t.timestamps null: false
+    end
+    add_index :collaborations, [:wiki_id, :user_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160309050627) do
+ActiveRecord::Schema.define(version: 20160325055522) do
+
+  create_table "collaborations", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "wiki_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "collaborations", ["wiki_id", "user_id"], name: "index_collaborations_on_wiki_id_and_user_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "name",                   default: "",    null: false

--- a/spec/controllers/collaborations_controller_spec.rb
+++ b/spec/controllers/collaborations_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CollaborationsController, type: :controller do
+
+end

--- a/spec/factories/collaborations.rb
+++ b/spec/factories/collaborations.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :collaboration do
+    
+  end
+end

--- a/spec/helpers/collaborations_helper_spec.rb
+++ b/spec/helpers/collaborations_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CollaborationsHelper. For example:
+#
+# describe CollaborationsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CollaborationsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/collaboration_spec.rb
+++ b/spec/models/collaboration_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Collaboration, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Added new feature of adding collaborators to private wikis.
Premium and Admin users can add other standard/premium users to view/edit their private wikis.
Edited the wiki show page to manage (add/remove) collaborators.
Added wiki policy.

---- edit
Edited wiki policy to include authorization
Standard users can only view private wikis if they are a collaborator
Fixed the error of premium users being able to see all private wikis with the url -- now premium users can't view other users' private wikis unless they are a collaborator
Added private buttons to private wikis
